### PR TITLE
Add server3

### DIFF
--- a/utils/qmsg_notify.py
+++ b/utils/qmsg_notify.py
@@ -7,6 +7,12 @@ if os.getenv("GITHUB_ACTIONS") is None:
 
 def send_qmsg_notification(content):
     qmsg_key = os.getenv('QMSG_KEY')  # 从环境变量中获取 Qmsg 酱的 key
+
+    # 检查 qmsg_key 是否为 None 或空字符串
+    if not qmsg_key:
+        print("⚠️ qmsg_key 未设置 请设置后重试！")
+        return
+
     qmsg_url = f'https://qmsg.zendee.cn/jsend/{qmsg_key}'
     headers = {
         'Content-Type': 'application/json'

--- a/utils/qywechat_notify.py
+++ b/utils/qywechat_notify.py
@@ -7,6 +7,12 @@ if os.getenv("GITHUB_ACTIONS") is None:
 
 def send_wechat_notification(content):
     webhook_key = os.getenv('WEBHOOK_KEY')
+
+    # 检查 webhook_key 是否为 None 或空字符串
+    if not webhook_key:
+        print("⚠️ webhook_key 未设置 请设置后重试！")
+        return
+
     wechat_webhook_url = f'https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key={webhook_key}'
     headers = {
         'Content-Type': 'application/json'

--- a/utils/serve_chan_notify.py
+++ b/utils/serve_chan_notify.py
@@ -8,6 +8,11 @@ if os.getenv("GITHUB_ACTIONS") is None:
 def send_server_chan_notification(title, desp):
     server_chan_key = os.getenv('SERVER_CHAN_KEY')
 
+    # 检查 server_chan_key 是否为 None 或空字符串
+    if not server_chan_key:
+        print("⚠️ SERVER_CHAN_KEY 未设置 请设置后重试！")
+        return
+
     # 根据 server_chan_key 的前缀决定使用不同的推送URL
     if server_chan_key.startswith('sctp'):
         server_chan_url = f'https://{server_chan_key}.push.ft07.com/send'

--- a/utils/serve_chan_notify.py
+++ b/utils/serve_chan_notify.py
@@ -5,20 +5,26 @@ from dotenv import load_dotenv
 if os.getenv("GITHUB_ACTIONS") is None:
     load_dotenv()
 
-def send_server_chan_notification(title, desp, channel=9):
+def send_server_chan_notification(title, desp):
     server_chan_key = os.getenv('SERVER_CHAN_KEY')
-    server_chan_url = f'https://sctapi.ftqq.com/{server_chan_key}.send'
+
+    # 根据 server_chan_key 的前缀决定使用不同的推送URL
+    if server_chan_key.startswith('sctp'):
+        server_chan_url = f'https://{server_chan_key}.push.ft07.com/send'
+    else:
+        server_chan_url = f'https://sctapi.ftqq.com/{server_chan_key}.send'
+    
     headers = {
-        'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36'
+        'Content-Type': 'application/json;charset=utf-8'
     }
+
     data = {
         'title': title,
-        'desp': desp,
-        'channel': channel
+        'desp': desp
     }
 
     try:
-        response = requests.post(server_chan_url, headers=headers, data=data)
+        response = requests.post(server_chan_url, json=data, headers=headers)
         response.raise_for_status()
         print("✅ Server酱通知发送成功。")
     except requests.exceptions.HTTPError as http_err:


### PR DESCRIPTION
1. 通过key来适配是Server酱还是Server酱3
2. 取消了Server酱方法的默认channel参数，因为：`channel: 动态指定本次推送使用的消息通道，选填。如不指定，则使用网站上的消息通道页面设置的通道。`
3. 如果消息通道的key不存在则不继续进行
4. 以上均已测试无问题
